### PR TITLE
fixed typo in link to child safety policy

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -359,7 +359,7 @@ export default {
             },
             {
                 "name":"Child Safety Policy",
-                "link":"/child-safty-policy"
+                "link":"/child-safety-policy"
             },
                         {
                 "name":"Youth Protection",


### PR DESCRIPTION
Found this bug when testing the portal, website, and server code in our staging environment. The current link sends the user to `child-safty-policy`, not `child-safety-policy`, resulting in a 404.

Simple fix.